### PR TITLE
MD file with a link to instructions on how to deploy FastHTML to PythonAnywhere.

### DIFF
--- a/deploying-to-pythonanywhere.md
+++ b/deploying-to-pythonanywhere.md
@@ -1,0 +1,5 @@
+# Deploying a FastHTML site to PythonAnywhere
+
+You can easily create and deploy FastHTML sites on PythonAnywhere; support
+for it is being continuously improved, and you'll find the latest instructions
+on [this help page](https://help.pythonanywhere.com/pages/FastHTML/).


### PR DESCRIPTION
Deploying FastHTML to PythonAnywhere is a moving target -- as new features are currently being added -- so this markdown file just points people to the help page with the most up-to-date instructions.

@jph00 for visibility.