### PR TITLE
fix: Allow messages to end with whitespace

### DIFF
--- a/02_chatbot/basic.py
+++ b/02_chatbot/basic.py
@@ -41,7 +41,7 @@ def get():
 # Handle the form submission
 @app.post("/")
 def post(msg:str):
-    messages.append({"role":"user", "content":msg})
+    messages.append({"role":"user", "content":msg.rstrip()})
     r = cli(messages, sp=sp) # get response from chat model
     messages.append({"role":"assistant", "content":contents(r)})
     return (ChatMessage(messages[-2]), # The user's message

--- a/02_chatbot/polling.py
+++ b/02_chatbot/polling.py
@@ -59,7 +59,7 @@ def get_response(r, idx):
 @app.post("/")
 def post(msg:str):
     idx = len(messages)
-    messages.append({"role":"user", "content":msg})
+    messages.append({"role":"user", "content":msg.rstrip()})
     r = cli(messages, sp=sp, stream=True) # Send message to chat model (with streaming)
     messages.append({"role":"assistant", "generating":True, "content":""}) # Response initially blank
     get_response(r, idx+1) # Start a new thread to fill in content

--- a/02_chatbot/ws.py
+++ b/02_chatbot/ws.py
@@ -46,7 +46,7 @@ def get():
 async def ws(msg:str, send):
 
     # Send the user message to the user (updates the UI right away)
-    messages.append({"role":"user", "content":msg})
+    messages.append({"role":"user", "content":msg.rstrip()})
     await send(Div(ChatMessage(messages[-1]), hx_swap_oob='beforeend', id="chatlist"))
 
     # Send the clear input field command to the user

--- a/02_chatbot/ws_streaming.py
+++ b/02_chatbot/ws_streaming.py
@@ -49,7 +49,7 @@ def get():
 
 @app.ws('/wscon')
 async def ws(msg:str, send):
-    messages.append({"role":"user", "content":msg})
+    messages.append({"role":"user", "content":msg.rstrip()})
 
     # Send the user message to the user (updates the UI right away)
     await send(Div(ChatMessage(len(messages)-1), hx_swap_oob='beforeend', id="chatlist"))


### PR DESCRIPTION
When the chat message ended with white space, claudette crashed. Right stripping prevents this.

Example error:

```
anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages: final assistant content cannot end with trailing whitespace'}}
```
