### PR TITLE
Fixed multiple typos in todo app examples

### DIFF
--- a/01_todo_app/README.md
+++ b/01_todo_app/README.md
@@ -82,7 +82,7 @@ Editing a todo item is handled by this route which takes the todo's id as a para
 @rt("/edit/{id}")
 async def get(id:int):
     res = Form(Group(Input(id="title"), Button("Save")),
-        Hidden(id="id"), CheckboxX(id="done", label='Done'),
+        Hidden(id="id"), Checkbox(id="done", label='Done'),
         hx_put="/", target_id=tid(id), id="edit")
     return fill_form(res, todos.get(id))
 ```

--- a/01_todo_app/main.py
+++ b/01_todo_app/main.py
@@ -37,7 +37,7 @@ async def post(todo:Todo): return todos.insert(todo), mk_input(hx_swap_oob='true
 @rt("/edit/{id}")
 async def get(id:int):
     res = Form(Group(Input(id="title"), Button("Save")),
-        Hidden(id="id"), CheckboxX(id="done", label='Done'),
+        Hidden(id="id"), Checkbox(id="done", label='Done'),
         hx_put="/", target_id=tid(id), id="edit")
     return fill_form(res, todos.get(id))
 

--- a/todos1/main.py
+++ b/todos1/main.py
@@ -34,7 +34,7 @@ async def post(todo:Todo): return todos.insert(todo), mk_input(hx_swap_oob='true
 @rt("/edit/{id}")
 async def get(id:int):
     res = Form(Group(Input(id="title"), Button("Save")),
-        Hidden(id="id"), CheckboxX(id="done", label='Done'),
+        Hidden(id="id"), Checkbox(id="done", label='Done'),
         hx_put="/", target_id=tid(id), id="edit")
     return fill_form(res, todos.get(id))
 

--- a/todos2-hf/main.py
+++ b/todos2-hf/main.py
@@ -46,7 +46,7 @@ async def post(todo:Todo): return todos.insert(todo), mk_input(hx_swap_oob='true
 @rt("/edit/{id}")
 async def get(id:int):
     res = Form(Group(Input(id="title"), Button("Save")),
-        Hidden(id="id"), CheckboxX(id="done", label='Done'),
+        Hidden(id="id"), Checkbox(id="done", label='Done'),
         hx_put="/", target_id=tid(id), id="edit")
     return fill_form(res, todos[id])
 

--- a/todos2/main.py
+++ b/todos2/main.py
@@ -94,7 +94,7 @@ def edit(id:int):
     res = Form(hx_post=replace, target_id=f'todo-{id}', id="edit")(
             Group(Input(id="title"), Button("Save")),
             Hidden(id="id"), Hidden(priority="priority"),
-            Hidden(name="done"), CheckboxX(id="done", label='Done'),
+            Hidden(name="done"), Checkbox(id="done", label='Done'),
             Textarea(id="details", name="details", rows=10))
     return fill_form(res, todos[id])
 


### PR DESCRIPTION
Fixes a crash caused by a copy-pasted typo (CheckboxX -> Checkbox) at GET /edit/{id} route for todo app examples