### PR TITLE
fix: TypeError: list indices must be integers or slices, not dict

### DIFF
--- a/02_chatbot/ws_streaming.py
+++ b/02_chatbot/ws_streaming.py
@@ -36,7 +36,7 @@ def ChatInput():
 @app.route("/")
 def get():
     page = Body(H1('Chatbot Demo'),
-                Div(*[ChatMessage(msg) for msg in messages],
+                Div(*[ChatMessage(msg_idx) for msg_idx, msg in enumerate(messages)],
                     id="chatlist", cls="chat-box h-[73vh] overflow-y-auto"),
                 Form(Group(ChatInput(), Button("Send", cls="btn btn-primary")),
                     ws_send=True, hx_ext="ws", ws_connect="/wscon",


### PR DESCRIPTION
When reloading a chat window you get this error:

```
ws_streaming.py", line 22, in ChatMessage
    msg = messages[msg_idx]
          ~~~~~~~~^^^^^^^^^
TypeError: list indices must be integers or slices, not dict
```