### PR TITLE
Remove `picolink` from `infinite_scroll` example

### DIFF
--- a/infinite_scroll/main.py
+++ b/infinite_scroll/main.py
@@ -1,8 +1,8 @@
-from fasthtml import FastHTML, picolink
+from fasthtml import FastHTML
 from fasthtml.common import *
 import random, uvicorn
 
-app = FastHTML(hdrs=(picolink,))
+app = FastHTML()
 
 def create_card(number):
     color = f"hsl({random.randint(0, 360)}, 70%, 80%)"


### PR DESCRIPTION
Fix error: Can't import `picolink` from `fasthtml`