### PR TITLE
Reset input field after user send a message

### DIFF
--- a/04_sse/sse_chatbot.py
+++ b/04_sse/sse_chatbot.py
@@ -111,7 +111,7 @@ async def send_message(msg: str):
             hx_swap="beforeend",
         )
     )
-    return user_msg, assistant_msg
+    return user_msg, assistant_msg, ChatInput()
 
 
 serve()


### PR DESCRIPTION
Return an additional `ChatInput()` in `send_message` to make sure the user input field is reset after the `Send` button is clicked.