### PR TITLE
Fix messages handling in send function to prevent API errors

### DIFF
--- a/02_chatbot/basic.py
+++ b/02_chatbot/basic.py
@@ -41,6 +41,7 @@ def index():
 @app.post
 def send(msg:str, messages:list[str]=None):
     if not messages: messages = []
+    messages = [str(obj) for obj in messages]        
     messages.append(msg.rstrip())
     r = contents(cli(messages, sp=sp)) # get response from chat model
     return (ChatMessage(msg, True),    # The user's message


### PR DESCRIPTION
This PR fixes a bug in the send function related to improper handling of the messages list, which led to a BadRequestError from the Anthropics API. The error message highlighted that text content blocks must contain non-whitespace text, which could happen if messages contained non-string objects or strings with only whitespace.

`anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages: text content blocks must contain non-whitespace text'}}`