### PR TITLE
Fix: Remove incorrect import of picolink to resolve import error in image classification example

### DIFF
--- a/image_classification_app/main.py
+++ b/image_classification_app/main.py
@@ -1,4 +1,4 @@
-from fasthtml import FastHTML, picolink
+from fasthtml import FastHTML
 from fasthtml.common import *
 import os, uvicorn
 from starlette.responses import FileResponse


### PR DESCRIPTION
While executing the file, I encountered the following error:

```ImportError: cannot import name 'picolink' from 'fasthtml'```

Upon further investigation, I discovered that `picolink` is located in `fasthtml.common`. Consequently, the import error was resolved by removing the incorrect import statement for `picolink`.

