### PR TITLE
database.py follows API updates regarding the redirect_uri

### DIFF
--- a/oauth_example/database.py
+++ b/oauth_example/database.py
@@ -8,12 +8,13 @@ if user_counts not in db.t:
     user_counts.create(dict(name=str, count=int), pk='name')
 Count = user_counts.dataclass()
 
+redirect_uri="http://localhost:8000/auth_redirect"
+
 # Auth client setup for GitHub
 client = GitHubAppClient(os.getenv("AUTH_CLIENT_ID"), 
-                         os.getenv("AUTH_CLIENT_SECRET"),
-                         redirect_uri="http://localhost:8000/auth_redirect")
-login_link = client.login_link()
+                         os.getenv("AUTH_CLIENT_SECRET"))
 
+login_link = client.login_link(redirect_uri)
 
 # Beforeware that puts the user_id in the request scope or redirects to the login page if not logged in.
 def before(req, session):
@@ -50,7 +51,7 @@ def increment(auth):
 @app.get('/login')
 def login(): 
     return Div(P("You are not logged in."), 
-               A('Log in with GitHub', href=client.login_link()))
+               A('Log in with GitHub', href=login_link))
 
 # To log out, we just remove the user_id from the session.
 @app.get('/logout')
@@ -66,7 +67,7 @@ def auth_redirect(code:str, session, state:str=None):
     print(f"state: {state}") # Not used in this example.
     try:
         # The code can be used once, to get the user info:
-        info = client.retr_info(code)
+        info = client.retr_info(code,redirect_uri)
         print(f"info: {info}")
         # Use client.retr_id(code) directly if you just want the id, otherwise get the id with:
         user_id = info[client.id_key]
@@ -91,3 +92,4 @@ def auth_redirect(code:str, session, state:str=None):
         return f"Could not log in."
 
 serve(port=8000)
+

--- a/oauth_example/requirements.txt
+++ b/oauth_example/requirements.txt
@@ -1,0 +1,1 @@
+python-fasthtml


### PR DESCRIPTION
This PR updates use of the redirect_uri to match the current API:

- redirect_uri is no longer passed to GitHubAppClient()
- it is passed to GitHubAppClient.login_link(redirect_uri)
- it is passed to GitHubAppClient.retr_info(code,redirect_uri)

I tested database.py with live credentials and it worked after this fix.
