### PR TITLE
Fixes to chess board

### DIFF
--- a/chess_app/chess_app.py
+++ b/chess_app/chess_app.py
@@ -65,11 +65,11 @@ ROWS = '87654321'
 COLS = 'abcdefgh'
 def Board(lmoves: list[str] = [], selected: str = ''):
     board = []
-    for row in ROWS:
+    for col in COLS:
         board_row = []
-        for col in COLS:
+        for row  in ROWS:
             pos = f"{col}{row}"
-            cell_color = "black" if (ROWS.index(row) + COLS.index(col)) % 2 == 0 else "white"
+            cell_color = "white" if (ROWS.index(row) + COLS.index(col)) % 2 == 0 else "black"
             cell_color = 'active' if pos in lmoves else cell_color
             cell_cls = f'board-cell {cell_color}'
             if pos == selected:


### PR DESCRIPTION
A few minor changes to bring the chess board in line with correct chess setup rules and online chess diagram display conventions.

- Display White and Black on bottom and top vertically, as on e.g. Chess.com or Lichess.
- Light square on the right hand side
- Queen on her own color

Before:
<img width="523" alt="Screenshot 2025-01-15 at 5 00 31 PM" src="https://github.com/user-attachments/assets/e98e7116-6415-4ee7-96a7-067d6496abce" />
After:
<img width="524" alt="Screenshot 2025-01-15 at 5 01 08 PM" src="https://github.com/user-attachments/assets/692a94e7-b18a-4457-9ac6-5495cd63aa1d" />
