### PR TITLE
Update OAuth documentation link

### DIFF
--- a/oauth_example/README.md
+++ b/oauth_example/README.md
@@ -1,6 +1,6 @@
 # OAuth Examples
 
-This directory contains some examples of OAuth in action. See the [docs](https://docs.fastht.ml/explains/oauth.html) for a more detailed explanation.
+This directory contains some examples of OAuth in action. See the [docs](https://fastht.ml/docs/explains/oauth.html) for a more detailed explanation.
 
 - minimal.py - initializes an OAuth client and retrieves the user's profile, displaying it in the browser after a successful login.
 - oa.py - a minimal example showing use of the OAuth class, gating access to the homepage to users with answer.ai email addresses.


### PR DESCRIPTION
Just updated the link to the new doc url: https://fastht.ml/docs/explains/oauth.html