### PR TITLE
Cli oauth update readme

### DIFF
--- a/cli_oauth_example/README.md
+++ b/cli_oauth_example/README.md
@@ -63,7 +63,7 @@ The authentication flow follows these steps:
 3. **User Authentication**:
    - The client opens the login URL in the user's browser
    - The user authenticates with the OAuth provider
-   - After approval, the provider redirects back with an authorization code (named `code` in the `cli-server.py`)
+   - After approval, the provider redirects back with an authorization code (named `code` in the `server.py`)
 
    ```python
    # From client-login.py
@@ -134,6 +134,20 @@ The authentication flow follows these steps:
        cookies = Path(cookie_file).read_json()
        client.cookies.update(cookies)
        return client
+
+   client = get_client(token_file)
+   url = f'http://{host}/secured'
+   res = client.get(url).text
+   print(res)
    ```
+
+   ```python
+   # From server.py - the secured endpoint
+   @rt
+   async def secured(sess):
+       return sess['auth']
+   ```
+
+   When the `/secured` endpoint is called, FastHTML automatically extracts the auth value from the session cookie. If authentication is valid, the endpoint returns the user's auth ID. If not, the request would fail because the session wouldn't contain valid authentication.
 
 For more detailed information about OAuth implementation in FastHTML, see the [OAuth documentation](https://fastht.ml/docs/explains/oauth.html).

--- a/cli_oauth_example/client-do.py
+++ b/cli_oauth_example/client-do.py
@@ -5,7 +5,7 @@ from fastcore.script import *
 def get_client(cookie_file):
     client = httpx.Client()
     cookies = Path(cookie_file).read_json()
-    for k,v in cookies.items(): client.cookies.set(k, v)
+    client.cookies.update(cookies)
     return client
 
 @call_parse
@@ -18,4 +18,3 @@ def auth_cli(
     url = f'http://{host}/secured'
     res = client.get(url).text
     print(res)
-

--- a/cli_oauth_example/server.py
+++ b/cli_oauth_example/server.py
@@ -34,7 +34,7 @@ async def token(paircode:str, sess):
         return auth
 
 @rt
-async def secured(sess, auth):
+async def secured(sess):
     return sess['auth']
 
 @rt


### PR DESCRIPTION
This PR:

1. Updates the readme to reflect the previously changed example code using the session cookie.
2. Makes a minor change for brevity: `for k,v in cookies.items(): client.cookies.set(k, v)` -> `client.cookies.update(cookies)`
3. Removes the unused `auth` arg in `async def secured(sess, auth):`

Please let me know if I missed a something re 2 and 3 but I thought this would be an improvement.