### PR TITLE
Update oauth_example/ to use hd claim

### DIFF
--- a/oauth_example/README.md
+++ b/oauth_example/README.md
@@ -3,7 +3,7 @@
 This directory contains some examples of OAuth in action. See the [docs](https://docs.fastht.ml/explains/oauth.html) for a more detailed explanation.
 
 - minimal.py - initializes an OAuth client and retrieves the user's profile, displaying it in the browser after a successful login.
-- oa.py - a minimal example showing use of the OAuth class, gating access to the homepage to users with answer.ai email addresses.
+- oa.py - a minimal example showing use of the OAuth class, gating access to the homepage to users who belong to the Google domain "answer.ai"
 - database.py - a legacy example used in an OAuth explanation, not recommended for use.
 
 

--- a/oauth_example/oa.py
+++ b/oauth_example/oa.py
@@ -5,8 +5,7 @@ cli = GoogleAppClient.from_file('/Users/jhoward/git/_nbs/oauth-test/client_secre
 
 class Auth(OAuth):
     def get_auth(self, info, ident, session, state):
-        email = info.email or ''
-        if info.email_verified and email.split('@')[-1]=='answer.ai':
+        if info.hd == 'answer.ai':
             return RedirectResponse('/', status_code=303)
 
 app = FastHTML()


### PR DESCRIPTION
Update oauth_example/ to use hd claim

Instead of checking if user has a verified email address which ends in "answer.ai", we check directly if the gmail account belongs to the "answer.ai" hosted domain.