### PR TITLE
Refactor xtermjs example

### DIFF
--- a/xtermjs/requirements.txt
+++ b/xtermjs/requirements.txt
@@ -1,2 +1,1 @@
 python-fasthtml
-monsterui

--- a/xtermjs/static/terminal.js
+++ b/xtermjs/static/terminal.js
@@ -1,14 +1,22 @@
-var term = new Terminal();
+import { FitAddon } from 'https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/+esm';
+
+const term = new Terminal();
+const fitAddon = new FitAddon();
+term.loadAddon(fitAddon);
 term.open(document.getElementById('terminal'));
+// fitAddon.fit();
 
-const socket = new WebSocket(`${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`);
-socket.onopen  = () => term.focus();
+const socket = new WebSocket(`/ws`);
+
+function resizeTerm() {
+  fitAddon.fit();
+  socket.send(JSON.stringify({cols:term.cols, rows:term.rows, HEADERS: {}}));
+}
+window.addEventListener('resize', () => resizeTerm());
+
+socket.onopen = () => {
+  resizeTerm();
+  term.focus();
+};
 socket.onmessage = ev => term.write(ev.data);
-
-term.onKey(e =>{
-  const ev = e.domEvent;
-  const printable = !ev.altKey && !ev.ctrlKey && !ev.metaKey;
-  if (printable) {
-    socket.send(JSON.stringify({msg: e.key, HEADERS: {}}));
-  }
-});
+term.onData(data => {socket.send(JSON.stringify({msg: data, HEADERS: {}}));});

--- a/xtermjs/static/terminal.js
+++ b/xtermjs/static/terminal.js
@@ -4,7 +4,6 @@ const term = new Terminal();
 const fitAddon = new FitAddon();
 term.loadAddon(fitAddon);
 term.open(document.getElementById('terminal'));
-// fitAddon.fit();
 
 const socket = new WebSocket(`/ws`);
 


### PR DESCRIPTION
This PR refactors the Xterm.js example to use a class for maintaining the terminal state. Additionally, it properly handles browser resizing to resize the terminal as well. These changes were ported over from changes that @jph00 made for a separate project.