### PR TITLE
Fix infinite scroll example: intersect trigger not firing

### DIFF
--- a/infinite_scroll/main.py
+++ b/infinite_scroll/main.py
@@ -23,7 +23,8 @@ def home():
             hx_get="/more-cards",
             hx_trigger="intersect once",
             hx_swap="afterend",
-            hx_target="#card-container"
+            hx_target="#card-container",
+            style="height: 1px;"
         ),
         style="max-width: 800px; margin: 0 auto;"
     )


### PR DESCRIPTION
The infinite scrolling doesn't work. Scrolling to the bottom of the page doesn't trigger `intersect once`.

According to the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API):

> Note that it's possible to have a zero intersection rectangle, which can happen if the intersection is exactly along the boundary between the two or the area of [boundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/boundingClientRect) is zero. This state of the target and root sharing a boundary line is **not considered enough to be considered transitioning into an intersecting state**.

So it's more reliable to have a div with a real area (by giving it height) to trigger `intersect`.

@jph00 