### PR TITLE
Fix counter-rsjs: replace $() with me()

### DIFF
--- a/htmx/utils.py
+++ b/htmx/utils.py
@@ -6,7 +6,7 @@ def extract_names(s): return [o for _,o,_,_ in Formatter().parse(s) if o is not 
 
 class RsJs:
     def __init__(self, nm): self.nm = nm
-    def ref(self, k): return f'$("[{self.data(k)}]", el)'
+    def ref(self, k): return f'me("[{self.data(k)}]", el)'
 
     def expand(self, s):
         d = {o:self.ref(o) for o in extract_names(s)}


### PR DESCRIPTION
The current version of Surreal doesn't seem to support $() as public API:
https://github.com/gnat/surreal?tab=readme-ov-file#-why-use-me--any-instead-of-

This fix replaces `$()` with `me()` so [counter-rsjs](https://github.com/AnswerDotAI/fasthtml-example/blob/main/htmx/counter-rsjs.py) example works 

@jph00 