### PR TITLE
Add missing `from fasthtml.pico import *`

### DIFF
--- a/00_game_of_life/main.py
+++ b/00_game_of_life/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 import asyncio
 import sys
 

--- a/01_todo_app/main.py
+++ b/01_todo_app/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 
 app,rt,todos,Todo = fast_app(
     'data/todos.db',

--- a/02_chatbot/basic.py
+++ b/02_chatbot/basic.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 from claudette import *
 
 # Set up the app, including daisyui and tailwind for the chat component

--- a/02_chatbot/chunked_transfer.py
+++ b/02_chatbot/chunked_transfer.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 from claudette import *
 from starlette.responses import StreamingResponse
 import asyncio

--- a/02_chatbot/polling.py
+++ b/02_chatbot/polling.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 from claudette import *
 
 # Set up the app, including daisyui and tailwind for the chat component

--- a/02_chatbot/ws.py
+++ b/02_chatbot/ws.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 from claudette import *
 import asyncio
 

--- a/02_chatbot/ws_streaming.py
+++ b/02_chatbot/ws_streaming.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 from claudette import *
 import asyncio
 

--- a/03_pictionary/main.py
+++ b/03_pictionary/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 import anthropic, os, base64, uvicorn
 
 key = os.environ.get("ANTHROPIC_API_KEY")

--- a/04_sse/sse_chatbot.py
+++ b/04_sse/sse_chatbot.py
@@ -1,5 +1,6 @@
 """Example from https://github.com/fabge/fasthtml-sse/"""
 from fasthtml.common import *
+from fasthtml.pico import *
 from claudette import *
 import asyncio
 from starlette.responses import StreamingResponse

--- a/annotate_text/main.py
+++ b/annotate_text/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 import json
 
 # Set up the app, including daisyui and tailwind for the chat component

--- a/code_highlight_and_copy/main.py
+++ b/code_highlight_and_copy/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 
 app = FastHTML(hdrs=(picolink, MarkdownJS(), HighlightJS()))
 

--- a/data_spot_check/main.py
+++ b/data_spot_check/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 import uuid, os, uvicorn, random, datasets
 import pandas as pd
 from starlette.responses import RedirectResponse, FileResponse  

--- a/doodle/main.py
+++ b/doodle/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 import uvicorn
 
 

--- a/file_upload_form_example/main.py
+++ b/file_upload_form_example/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 import uvicorn
 
 app = FastHTML(hdrs=(picolink,))

--- a/htmx/click-load.py
+++ b/htmx/click-load.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 from asyncio import sleep
 from random import randint
 import secrets

--- a/htmx/formdemo.py
+++ b/htmx/formdemo.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 app,rt = fast_app(live=True)
 
 @rt

--- a/htmx/oob.py
+++ b/htmx/oob.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 
 app,rt = fast_app()
 

--- a/image_app_session_credits/main.py
+++ b/image_app_session_credits/main.py
@@ -1,5 +1,6 @@
 from fastcore.parallel import threaded
 from fasthtml.common import *
+from fasthtml.pico import *
 import uuid, os, uvicorn, requests, replicate, stripe
 from PIL import Image
 from starlette.responses import RedirectResponse

--- a/image_app_session_credits/session.py
+++ b/image_app_session_credits/session.py
@@ -1,5 +1,6 @@
 from fastcore.parallel import threaded
 from fasthtml.common import *
+from fasthtml.pico import *
 import uuid, os, uvicorn, requests, replicate
 from PIL import Image
 

--- a/image_app_simple/draft1.py
+++ b/image_app_simple/draft1.py
@@ -1,5 +1,6 @@
 from fastcore.parallel import threaded
 from fasthtml.common import *
+from fasthtml.pico import *
 import os, uvicorn, requests, replicate
 from PIL import Image
 

--- a/image_app_simple/main.py
+++ b/image_app_simple/main.py
@@ -1,5 +1,6 @@
 from fastcore.parallel import threaded
 from fasthtml.common import *
+from fasthtml.pico import *
 import uuid, os, uvicorn, requests, replicate
 from PIL import Image
 

--- a/image_classification_app/main.py
+++ b/image_classification_app/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 import os, uvicorn
 from starlette.responses import FileResponse
 from starlette.datastructures import UploadFile

--- a/todos1/main.py
+++ b/todos1/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 
 app,rt,todos,Todo = fast_app('data/todos.db',
     id=int, title=str, done=bool, pk='id')

--- a/todos2-hf/main.py
+++ b/todos2-hf/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 from fasthtml_hf import setup_hf_backup
 
 def tid(id): return f'todo-{id}'

--- a/todos2/main.py
+++ b/todos2/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 from hmac import compare_digest
 # required for sqlalchemy:
 # from fastsql import *

--- a/xtermjs/main.py
+++ b/xtermjs/main.py
@@ -1,4 +1,5 @@
 from fasthtml.common import *
+from fasthtml.pico import *
 
 import asyncio, fcntl, os, pty, select, signal, struct, termios
 


### PR DESCRIPTION
Pico components are no longer exported from `fasthtml.common`. Many examples still use them without importing.

Fixed by adding: `from fasthtml.pico import *`

```
./00_game_of_life/main.py              -> picolink
./01_todo_app/main.py                  -> Card,Group
./02_chatbot/basic.py                  -> Group,picolink
./02_chatbot/chunked_transfer.py       -> Group,picolink
./02_chatbot/polling.py                -> Group,picolink
./02_chatbot/ws.py                     -> Group,picolink
./02_chatbot/ws_streaming.py           -> Group,picolink
./03_pictionary/main.py                -> picolink
./04_sse/sse_chatbot.py                -> Group,picolink
./annotate_text/main.py                -> picolink
./code_highlight_and_copy/main.py      -> picolink
./data_spot_check/main.py              -> picolink
./doodle/main.py                       -> Group
./file_upload_form_example/main.py     -> Group,picolink
./htmx/click-load.py                   -> PicoBusy
./htmx/formdemo.py                     -> Grid
./htmx/oob.py                          -> Grid
./image_app_session_credits/main.py    -> Card,Group,picolink
./image_app_session_credits/session.py -> Card,Group,picolink
./image_app_simple/draft1.py           -> Group,picolink
./image_app_simple/main.py             -> Card,Group,picolink
./image_classification_app/main.py     -> picolink
./todos1/main.py                       -> Card,Group
./todos2/main.py                       -> Card,Container,Grid,Group
./todos2-hf/main.py                    -> Card,Grid,Group
./xtermjs/main.py                      -> Card
```
